### PR TITLE
Run Hyperion as root to fix mmap issue

### DIFF
--- a/stage-hyperbian/00-install-hyperion/00-run.sh
+++ b/stage-hyperbian/00-install-hyperion/00-run.sh
@@ -31,5 +31,5 @@ echo '---> Installing Hyperion'
 apt-get -y install hyperion
 echo '---> Registering Hyperion'
 mv /etc/systemd/system/hyperiond@.service /etc/systemd/system/hyperion@.service
-systemctl -q enable hyperion"@pi".service
+systemctl -q enable hyperion"@root".service
 EOF

--- a/stage-hyperbian/00-install-hyperion/files/motd-hyperbian
+++ b/stage-hyperbian/00-install-hyperion/files/motd-hyperbian
@@ -18,7 +18,7 @@ printf "|_|  |_|    |_|    |_|      |______| |_|  \_\ |____/  |_| /_/    \_\ |_|
 printf "\nTo configure Hyperion browse to ${BLUE}http://${IP}:8090${NC} from another device on your network."
 printf "\nAll Hyperion configuration can be completed via the Hyperion Web UI.\n\n"
 
-systemctl is-active hyperion@pi.service >/dev/null 2>&1 && printf "Hyperion status: ${GREEN}⬤  Running${NC}\n" || printf "Hyperion status: ${RED}⬤  Stopped${NC}\n"
+systemctl is-active hyperion@root.service >/dev/null 2>&1 && printf "Hyperion status: ${GREEN}⬤  Running${NC}\n" || printf "Hyperion status: ${RED}⬤  Stopped${NC}\n"
 
 printf "\n${BOLD}* Documentation: ${NC}${GREEN}https://docs.hyperion-project.org${NC}"
 printf "\n${BOLD}* Website:       ${NC}${GREEN}https://hyperion-project.org${NC}"


### PR DESCRIPTION
Hyperion needs to run as root to be able to use WS281x LEDs