### PR TITLE
Default user pi restored

### DIFF
--- a/config
+++ b/config
@@ -1,3 +1,6 @@
 IMG_NAME='HyperBian'
 STAGE_LIST='stage0 stage1 stage2 stage-hyperbian'
 TARGET_HOSTNAME='HyperBian'
+DISABLE_FIRST_BOOT_USER_RENAME=1
+FIRST_USER_NAME='pi'
+FIRST_USER_PASS='raspberry'


### PR DESCRIPTION
Since the default user 'pi' has been removed, it is hereby added back.